### PR TITLE
Refactor parse to read from iterable instead of list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,11 +23,11 @@ Usage
 
 .. code-block:: python
 
-    from bankline_parser.data_services import parse_file, parse
+    from bankline_parser.data_services import parse
 
     # from file
     with open(filename) as f:
-        parsed = parse_file(f)
+        parsed = parse(f)
         if parsed.is_valid():
             print(parsed.account.records[0].transaction_code)
         else:

--- a/bankline_parser/data_services/__init__.py
+++ b/bankline_parser/data_services/__init__.py
@@ -1,1 +1,1 @@
-from .parser import parse, parse_file
+from .parser import parse

--- a/bankline_parser/data_services/parser.py
+++ b/bankline_parser/data_services/parser.py
@@ -3,15 +3,8 @@ from .exceptions import ParseError
 from .utils import IndexTrackingIterator
 
 
-def parse_file(f):
-    return parse(f.readlines())
-
-
-def parse(lines):
-    if len(lines) == 0:
-        raise ParseError("Empty file provided")
-
-    lines_iter = IndexTrackingIterator(lines)
+def parse(iterable):
+    lines_iter = IndexTrackingIterator(iterable)
 
     def parse_account(lines_iter):
         # check for end of iteration on opening label of next account
@@ -57,3 +50,5 @@ def parse(lines):
         return models.DataServicesFile(volume_header_label, accounts)
     except ParseError as e:
         raise ParseError("Line %s: %s" % (lines_iter.current_index, e))
+    except StopIteration:
+        raise ParseError("File ended unexpectedly")

--- a/bankline_parser/data_services/utils.py
+++ b/bankline_parser/data_services/utils.py
@@ -1,7 +1,7 @@
 class IndexTrackingIterator(object):
 
-    def __init__(self, list):
-        self.iterator = iter(list)
+    def __init__(self, lines):
+        self.iterator = iter(lines)
         self.current_index = 0
 
     def __next__(self):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,6 +1,6 @@
 import unittest
 
-from bankline_parser.data_services import parse_file, parse
+from bankline_parser.data_services import parse
 from bankline_parser.data_services.exceptions import ParseError
 
 from .test_models import vhl_row
@@ -10,7 +10,7 @@ class DataServicesParserTestCase(unittest.TestCase):
 
     def test_nwb_testfile_successful_parse(self):
         with open('tests/data/testfile_nwb') as f:
-            output = parse_file(f)
+            output = parse(f)
 
         self.assertTrue(output.is_valid())
         self.assertEqual(len(output.accounts), 1)
@@ -26,7 +26,7 @@ class DataServicesParserTestCase(unittest.TestCase):
 
     def test_rbs_testfile_successful_parse(self):
         with open('tests/data/testfile_rbs') as f:
-            output = parse_file(f)
+            output = parse(f)
 
         self.assertTrue(output.is_valid())
         self.assertEqual(len(output.accounts), 1)


### PR DESCRIPTION
This also allows parse to accept a file as an argument
directly, without needing to call readlines() first.
