### PR TITLE
Migrate to modern/declarative packaging

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,9 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.x
-      - name: Install linting dependencies
-        run: pip install -U setuptools pip wheel -r requirements-lint.txt
+      - name: Update setuptools pip and wheel
+        run: pip install -U setuptools pip wheel
+      - name: Install linting requirements
+        run: pip install -r requirements-lint.txt
       - name: Lint code
         run: flake8 --verbose

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,13 @@ jobs:
           python-version: 3.x
       - name: Update setuptools pip and wheel
         run: pip install -U setuptools pip wheel
-      - name: Install twine
-        run: pip install twine
+      - name: Install release requirements
+        run: pip install -r requirements-release.txt
       - name: Build and release to PYPI
         run: |
-          python setup.py sdist bdist_wheel
+          python -m build
+          unzip -l dist/*.whl
+          tar tzf dist/*.tar.gz
           twine upload --non-interactive dist/*
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,4 +22,6 @@ jobs:
       - name: Update setuptools pip and wheel
         run: pip install -U setuptools pip wheel
       - name: Run tests
-        run: python -m tests
+        run: |
+          pip install --editable .
+          python -m tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,4 +22,4 @@ jobs:
       - name: Update setuptools pip and wheel
         run: pip install -U setuptools pip wheel
       - name: Run tests
-        run: python setup.py test
+        run: python -m tests

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help clean test test-all coverage release
+.PHONY: help clean test test-all coverage lint release
 
 help:
 	@echo "Using make is entirely optional; these are simply shortcuts"
@@ -8,6 +8,7 @@ help:
 	@echo "test - run all tests using current python environment"
 	@echo "test-all - run all tests in all supported python environments"
 	@echo "coverage - check code coverage while running all tests using current python environment"
+	@echo "lint - check code style"
 	@echo "release - NOT NORMALLY USED; See README.rst for release process"
 
 clean:
@@ -15,8 +16,8 @@ clean:
 	find . -name '*.pyc' -exec rm -f {} +
 	find . -name '__pycache__' -exec rm -fr {} +
 
-test: clean
-	python setup.py test
+test:
+	python -m tests
 
 test-all:
 	pip install --upgrade tox
@@ -26,6 +27,10 @@ coverage:
 	pip install --upgrade coverage
 	coverage run setup.py test
 	coverage report --show-missing
+
+lint:
+	pip install -r requirements-lint.txt
+	flake8 --verbose
 
 release: clean
 	pip install --upgrade twine

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
-.PHONY: help clean test test-all coverage lint release
+.PHONY: help init clean test test-all coverage lint release
 
 help:
 	@echo "Using make is entirely optional; these are simply shortcuts"
 	@echo "See README.rst for normal usage."
 	@echo ""
+	@echo "init - create virtual environment"
 	@echo "clean - remove all build and test artifacts"
 	@echo "test - run all tests using current python environment"
 	@echo "test-all - run all tests in all supported python environments"
@@ -11,12 +12,19 @@ help:
 	@echo "lint - check code style"
 	@echo "release - NOT NORMALLY USED; See README.rst for release process"
 
+init:
+	[ -d venv ] || python -m venv venv
+	./venv/bin/pip install -U setuptools pip wheel
+	./venv/bin/pip install --editable .
+	@echo `./venv/bin/python --version` virtual environment installed. Activate it using '`. ./venv/bin/activate`'
+
 clean:
 	rm -fr build/ dist/ .eggs/ .tox/ .coverage
 	find . -name '*.pyc' -exec rm -f {} +
 	find . -name '__pycache__' -exec rm -fr {} +
 
 test:
+	pip install --editable .
 	python -m tests
 
 test-all:

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,6 @@ lint:
 	flake8 --verbose
 
 release: clean
-	pip install --upgrade twine
-	python setup.py sdist bdist_wheel
+	pip install -r requirements-release.txt
+	python -m build
 	twine upload dist/*

--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,9 @@ Development
 
 Please report bugs and open pull requests on `GitHub`_.
 
+To work on changes to this library, it’s recommended to install it in editable mode into a virtual environment,
+i.e. ``pip install --editable .``
+
 Use ``python -m tests`` to run all tests locally.
 Alternatively, you can use ``tox`` if you have multiple python versions.
 

--- a/README.rst
+++ b/README.rst
@@ -57,15 +57,22 @@ Development
 
 Please report bugs and open pull requests on `GitHub`_.
 
-Use ``python setup.py test`` or ``tox`` to run all tests.
+Use ``python -m tests`` to run all tests locally.
+Alternatively, you can use ``tox`` if you have multiple python versions.
 
-Distribute a new version to `PyPI`_ by updating the ``VERSION`` tuple in ``bankline_parser/__init__.py`` and
-publishing a release in GitHub (this triggers a GitHub Actions workflow to automatically upload it).
-Alternatively, run ``python setup.py sdist bdist_wheel upload`` locally.
-Remember to update `History`_.
+[Only for GitHub team members] Distribute a new version to `PyPI`_ by:
+
+- updating the ``VERSION`` tuple in ``bankline_parser/__init__.py``
+- adding a note to the `History`_
+- publishing a release on GitHub which triggers an upload to PyPI;
+  alternatively, run ``python setup.py sdist bdist_wheel upload`` locally
 
 History
 -------
+
+Unreleased
+    Migrated test, build and release processes away from deprecated setuptools commands.
+    No significant library changes.
 
 0.7
     Maintenance release, no library changes.

--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ Alternatively, you can use ``tox`` if you have multiple python versions.
 - updating the ``VERSION`` tuple in ``bankline_parser/__init__.py``
 - adding a note to the `History`_
 - publishing a release on GitHub which triggers an upload to PyPI;
-  alternatively, run ``python setup.py sdist bdist_wheel upload`` locally
+  alternatively, run ``python -m build; twine upload dist/*`` locally
 
 History
 -------

--- a/bankline_parser/__init__.py
+++ b/bankline_parser/__init__.py
@@ -1,3 +1,2 @@
 VERSION = (0, 7)
 __version__ = '.'.join(map(str, VERSION))
-__author__ = 'Ministry of Justice Digital & Technology'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/requirements-release.txt
+++ b/requirements-release.txt
@@ -1,0 +1,2 @@
+build
+twine

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,38 @@
+[metadata]
+name = bankline-direct-parser
+version = attr: bankline_parser.__version__
+url = https://github.com/ministryofjustice/bankline-direct-parser
+author = Ministry of Justice Digital & Technology
+author_email = dev@digital.justice.gov.uk
+description = Parser for Bankline Direct banking information services
+long_description = file: README.rst
+license = MIT
+keywords =
+    bankline
+classifiers =
+    Development Status :: 4 - Beta
+    Intended Audience :: Developers
+    License :: OSI Approved :: MIT License
+    Natural Language :: English
+    Operating System :: OS Independent
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Topic :: Software Development :: Libraries :: Python Modules
+
+[options]
+; NB: looser python version requirement than what's tested
+python_requires = >=3.6
+packages =
+    bankline_parser
+    bankline_parser.data_services
+include_package_data = true
+test_suite = tests
+
 [flake8]
 exclude = .git/,.eggs/,.tox/,build/,dist/,env/,venv/
 max-complexity = 10

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,6 @@ packages =
     bankline_parser
     bankline_parser.data_services
 include_package_data = true
-test_suite = tests
 
 [flake8]
 exclude = .git/,.eggs/,.tox/,build/,dist/,env/,venv/

--- a/setup.py
+++ b/setup.py
@@ -1,48 +1,10 @@
 #!/usr/bin/env python
-import importlib
-import os
 import sys
 import warnings
 
 from setuptools import setup
 
 if sys.version_info[0:2] < (3, 7):
-    warnings.warn('This package is tested with Python version 3.7+', stacklevel=1)
+    warnings.warn('This package is only tested on Python version 3.7+', stacklevel=1)
 
-root_path = os.path.abspath(os.path.dirname(__file__))
-
-with open(os.path.join(root_path, 'README.rst')) as readme:
-    README = readme.read()
-
-package_info = importlib.import_module('bankline_parser')
-
-setup(
-    name='bankline-direct-parser',
-    version=package_info.__version__,
-    author=package_info.__author__,
-    author_email='dev@digital.justice.gov.uk',
-    url='https://github.com/ministryofjustice/bankline-direct-parser',
-    packages=['bankline_parser', 'bankline_parser.data_services'],
-    include_package_data=True,
-    license='MIT',
-    description='Parser for Bankline Direct banking information services',
-    long_description=README,
-    classifiers=[
-        'Development Status :: 4 - Beta',
-        'Framework :: Django',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
-        'Natural Language :: English',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
-        'Programming Language :: Python :: 3.11',
-    ],
-    python_requires='>=3.6',  # looser requirement than what's tested
-    install_requires=[],
-    tests_require=[],
-    test_suite='tests',
-)
+setup()

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -1,0 +1,9 @@
+import pathlib
+import unittest
+
+if __name__ == '__main__':
+    tests_path = pathlib.Path(__file__).parent
+    root_path = tests_path.parent
+    test_suite = unittest.defaultTestLoader.discover(start_dir=str(tests_path), top_level_dir=str(root_path))
+    test_runner = unittest.runner.TextTestRunner(verbosity=2)
+    test_runner.run(test_suite)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,7 +1,6 @@
 import unittest
 
-from bankline_parser.data_services import fields
-from bankline_parser.data_services import enums
+from bankline_parser.data_services import enums, fields
 from bankline_parser.data_services.exceptions import ParseError
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,8 +1,7 @@
 import unittest
 from datetime import datetime
 
-from bankline_parser.data_services import models
-from bankline_parser.data_services import enums
+from bankline_parser.data_services import enums, models
 
 vhl_row = (
     'VOL1                                 ****830000                '

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =
 
 [testenv]
 description = run tests
-commands = python setup.py test
+commands = python -m tests
 
 [testenv:lint]
 description = lint code


### PR DESCRIPTION
Using declarative package metadata is now recommended and `setup.py` use should be minimised.

- `setup.py test` warns that it is deprecated; will instead use system-provided `unittest` via a script
- `setup.py sdist` & `setup.py bdist_wheel` should be replaced by a dedicated build tool, e.g. [build](https://pypi.org/project/build/)
- `setup.py upload` is very outdated, must be replaced with [twine](https://pypi.org/project/twine/)